### PR TITLE
fix php 8.4 error: implicitly nullable

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -134,7 +134,7 @@ class Client implements RequestFactoryInterface, UriFactoryInterface, StreamFact
         return new MdcUrlHelper($this);
     }
 
-    public function getApiUrl(string $path = null): string
+    public function getApiUrl(?string $path = null): string
     {
         $url = sprintf(
             static::API_ROUTE,

--- a/src/Endpoint/Authorization/NotAuthorizedException.php
+++ b/src/Endpoint/Authorization/NotAuthorizedException.php
@@ -19,7 +19,7 @@ final class NotAuthorizedException extends Exception
 {
     protected ?ResponseInterface $response;
 
-    public function __construct($message = '', $code = 0, Throwable $previous = null, ?ResponseInterface $response = null)
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null, ?ResponseInterface $response = null)
     {
         parent::__construct($message, $code, $previous);
         $this->response = $response;

--- a/src/Http/Asset/CreateShareLinksRequest.php
+++ b/src/Http/Asset/CreateShareLinksRequest.php
@@ -32,7 +32,7 @@ final class CreateShareLinksRequest extends Request
      * @param bool $allowPresets If true, can be downloaded as a preset.
      * @param bool $displayMetadata If true, user can view metadata.
      */
-    public function __construct(string $expires = null, bool $hideShareBy = true, bool $allowDownloadOriginal = true, bool $allowCropAndResize = true, bool $allowPresets = true, bool $displayMetadata = false)
+    public function __construct(?string $expires = null, bool $hideShareBy = true, bool $allowDownloadOriginal = true, bool $allowCropAndResize = true, bool $allowPresets = true, bool $displayMetadata = false)
     {
         $this->expires = $expires;
         $this->hideShareBy = $hideShareBy;

--- a/src/Http/InvalidResponseException.php
+++ b/src/Http/InvalidResponseException.php
@@ -19,7 +19,7 @@ final class InvalidResponseException extends Exception
 {
     protected ?ResponseInterface $response;
 
-    public function __construct($message = '', $code = 0, Throwable $previous = null, ?ResponseInterface $response = null)
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null, ?ResponseInterface $response = null)
     {
         parent::__construct($message, $code, $previous);
         $this->response = $response;

--- a/src/Http/Upload/UploadFileRequest.php
+++ b/src/Http/Upload/UploadFileRequest.php
@@ -28,7 +28,7 @@ final class UploadFileRequest extends UploadRequest
     private ?string $tag = null;
     private ?string $albumId = null;
 
-    public function __construct(string $filePath, GetUploadSettingResponse $settings, string $referId = null)
+    public function __construct(string $filePath, GetUploadSettingResponse $settings, ?string $referId = null)
     {
         $this->filePath = $filePath;
         $this->settings = $settings;


### PR DESCRIPTION
Deprecated in PHP 8.4: Parameter #3 $xxx (type) is implicitly nullable via default value null